### PR TITLE
Oprava bugu v RegExpu

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -42,7 +42,7 @@ function getRandomInt(min, max) {
 // ========================================================================== //
 
 controller.hears(
-  ['^ob[eě]d\\?)*'],
+  ['^ob[eě]d(\\?)*'],
   ['ambient'],
   function (bot, message) {
     bot.api.reactions.add({


### PR DESCRIPTION
Opravuje bug v regulárním výrazu, kvůli kterému padal bot při zmínce slova oběd.
